### PR TITLE
Rename head ref & sha outputs and add base ref & sha outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Deprecated `ref` and `sha` outputs in favor of `head_ref` and `head_sha`.
+- Added `base_ref` and `base_sha` outputs
 - Bumped `@actions/core` from 1.2.2 to 1.2.5
 - Bumped `@actions/github` from 2.1.1 to 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Deprecated `ref` and `sha` outputs in favor of `head_ref` and `head_sha`.
 - Bumped `@actions/core` from 1.2.2 to 1.2.5
 - Bumped `@actions/github` from 2.1.1 to 4.0.0
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
         if: success()
         with:
-          ref: ${{ steps.comment-branch.outputs.ref }}
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
 
       - run: git rev-parse --abbrev-ref HEAD
       - run: git rev-parse --verify HEAD
@@ -48,8 +48,10 @@ Name | Allowed values | Description
 
 Name | Decription
 -- | --
-`ref` | The name of the pull request branch the comment belongs to.
-`sha` | The head sha of the pull request branch the comment belongs to.
+`head_ref` | The name of the pull request branch the comment belongs to.
+`head_sha` | The head sha of the pull request branch the comment belongs to.
+`ref` | Deprecated, use `head_ref` instead.
+`sha` | Deprecated, use `head_sha` instead.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Name | Allowed values | Description
 
 Name | Decription
 -- | --
+`base_ref` | The name of the branch the pull request will merge into.
+`base_sha` | The head sha of the branch the pull request will merge into.
 `head_ref` | The name of the pull request branch the comment belongs to.
 `head_sha` | The head sha of the pull request branch the comment belongs to.
 `ref` | Deprecated, use `head_ref` instead.

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     required: true
 
 outputs:
+  base_ref:
+    description: "The name of the branch the pull request will merge into."
+  base_sha:
+    description: "The head sha of the branch the pull request will merge into."
   head_ref:
     description: "The name of the pull request branch the comment belongs to."
   head_sha:

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,15 @@ inputs:
     required: true
 
 outputs:
+  head_ref:
+    description: "The name of the pull request branch the comment belongs to."
+  head_sha:
+    description: "The head sha of the pull request branch the comment belongs to."
+# deprecated outputs
   ref:
-    description: "The head ref of the pull request the comment belongs to."
+    description: "Deprecated, use head_ref instead."
   sha:
-    description: "The head sha of the pull request the comment belongs to."
+    description: "Deprecated, use head_sha instead."
 
 runs:
   using: "node12"

--- a/src/PullRequests.ts
+++ b/src/PullRequests.ts
@@ -1,0 +1,76 @@
+import { context, getOctokit } from "@actions/github";
+
+interface PullRequestDetailsResponse {
+  repository: {
+    pullRequest: {
+      headRef: {
+        name: string;
+        target: {
+          oid: string;
+        };
+      };
+      baseRef: {
+        name: string;
+        target: {
+          oid: string;
+        };
+      };
+    };
+  };
+}
+
+export async function isPullRequest(token: string) {
+  const client = getOctokit(token);
+
+  const { data: { pull_request } } = await client.issues.get({
+    ...context.repo,
+    issue_number: context.issue.number,
+  });
+
+  return !!pull_request;
+}
+
+export async function pullRequestDetails(token: string) {
+  const client = getOctokit(token);
+
+  const {
+    repository: {
+      pullRequest: {
+        baseRef,
+        headRef,
+      },
+    },
+  } = await client.graphql<PullRequestDetailsResponse>(
+    `
+      query pullRequestDetails($repo:String!, $owner:String!, $number:Int!) {
+        repository(name: $repo, owner: $owner) {
+          pullRequest(number: $number) {
+            baseRef {
+              name
+              target {
+                oid
+              }
+            }
+            headRef {
+              name
+              target {
+                oid
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      ...context.repo,
+      number: context.issue.number
+    },
+  );
+
+  return {
+    base_ref: baseRef.name,
+    base_sha: baseRef.target.oid,
+    head_ref: headRef.name,
+    head_sha: headRef.target.oid,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,13 +14,17 @@ export async function run() {
       throw Error("Comment is not on a pull request");
     }
 
-    const { data: { head: { ref, sha } } } = await client.pulls.get({
+    const { data: { head } } = await client.pulls.get({
       ...context.repo,
       pull_number: context.issue.number,
     });
 
-    setOutput("ref", ref);
-    setOutput("sha", sha);
+    setOutput("head_ref", head.ref);
+    setOutput("head_sha", head.sha);
+
+    // Deprecated
+    setOutput("ref", head.ref);
+    setOutput("sha", head.sha);
   } catch (error) {
     setFailed(error.message);
     throw error;

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,11 +14,13 @@ export async function run() {
       throw Error("Comment is not on a pull request");
     }
 
-    const { data: { head } } = await client.pulls.get({
+    const { data: { base, head } } = await client.pulls.get({
       ...context.repo,
       pull_number: context.issue.number,
     });
 
+    setOutput("base_ref", base.ref);
+    setOutput("base_sha", base.sha);
     setOutput("head_ref", head.ref);
     setOutput("head_sha", head.sha);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,32 +1,30 @@
 import { getInput, setFailed, setOutput } from "@actions/core";
-import { context, getOctokit } from "@actions/github";
+
+import { isPullRequest, pullRequestDetails } from "./PullRequests";
 
 export async function run() {
   try {
-    const client = getOctokit(getInput("repo_token", { required: true }));
+    const token = getInput("repo_token", { required: true });
 
-    const { data: { pull_request } } = await client.issues.get({
-      ...context.repo,
-      issue_number: context.issue.number,
-    });
-
-    if (!pull_request) {
+    if (!isPullRequest(token)) {
       throw Error("Comment is not on a pull request");
     }
 
-    const { data: { base, head } } = await client.pulls.get({
-      ...context.repo,
-      pull_number: context.issue.number,
-    });
+    const {
+      base_ref,
+      base_sha,
+      head_ref,
+      head_sha,
+    } = await pullRequestDetails(token);
 
-    setOutput("base_ref", base.ref);
-    setOutput("base_sha", base.sha);
-    setOutput("head_ref", head.ref);
-    setOutput("head_sha", head.sha);
+    setOutput("base_ref", base_ref);
+    setOutput("base_sha", base_sha);
+    setOutput("head_ref", head_ref);
+    setOutput("head_sha", head_sha);
 
     // Deprecated
-    setOutput("ref", head.ref);
-    setOutput("sha", head.sha);
+    setOutput("ref", head_ref);
+    setOutput("sha", head_sha);
   } catch (error) {
     setFailed(error.message);
     throw error;


### PR DESCRIPTION
This deprecates the `ref` & `sha` outputs in favor of `head_ref` and `head_sha` and adds two new outputs called `base_ref` and `base_sha` that pull the branch info the pr is merging into.

Closes #68 