### PR TITLE
Build directly from typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "description": "Gets the head ref and sha of a pull request comment",
-  "main": "lib/main.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "package": "ncc build --source-map --license license.txt",
+    "package": "ncc build ./src/main.ts --source-map --license license.txt",
     "release": "npm run package && git add -f dist/",
     "test": "tsc --noEmit"
   },


### PR DESCRIPTION
Version 0.24.0 of ncc doesn't work the same as prior versions and the dependencies get bundled incorrectly when using the compiled JS as the source, but it works fine when bundling from the TS files. This seems to be the recommended way of doing this despite how it's shown in [actions/typescript-action](https://github.com/actions/typescript-action).