### PR TITLE
Default `repo_token` input to `GITHUB_TOKEN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bumped `@actions/core` from 1.2.5 to 1.2.7
+- Updated the `repo_token` input so it defaults to `GITHUB_TOKEN`. If you're already using this value you can remove this setting from your workflow.
 
 ## Version 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ jobs:
     steps:
       - uses: xt0rted/pull-request-comment-branch@v1
         id: comment-branch
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v2
         if: success()
@@ -42,7 +40,7 @@ jobs:
 
 Name | Allowed values | Description
 -- | -- | --
-`repo_token` | `GITHUB_TOKEN` or a custom value | The token used to call the GitHub api.
+`repo_token` | `GITHUB_TOKEN` (default) or PAT | `GITHUB_TOKEN` token or a repo scoped PAT.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ With this action you'll be able to pass the ref to [`actions/checkout`](https://
 ```yml
 on:
   issue_comment:
-    types: created
+    types: [created]
 
 jobs:
   pr-comment:
@@ -32,6 +32,38 @@ jobs:
 
       - run: git rev-parse --abbrev-ref HEAD
       - run: git rev-parse --verify HEAD
+```
+
+## Token Permissions
+
+If your repository is using [token permissions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions) you'll need to set `contents: read` and `pull-request: read` on either the workflow or the job.
+
+### Workflow Config
+
+```yml
+on: issue_comment
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  pr-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: xt0rted/pull-request-comment-branch@v1
+```
+
+### Job Config
+
+```yml
+on: issue_comment
+jobs:
+  pr-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: xt0rted/pull-request-comment-branch@v1
 ```
 
 ## Options

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,9 @@ branding:
 
 inputs:
   repo_token:
-    description: "The GITHUB_TOKEN secret"
+    description: "GITHUB_TOKEN token or a repo scoped PAT"
     required: true
+    default: ${{ github.token }}
 
 outputs:
   base_ref:


### PR DESCRIPTION
This update makes it so the `repo_token` input value defaults to `GITHUB_TOKEN` which is the most common value to be used as it provides the necessary permissions. This is a backwards compatible change.