### PR TITLE
Support deleted PR branch

### DIFF
--- a/src/PullRequests.ts
+++ b/src/PullRequests.ts
@@ -3,7 +3,7 @@ import { context, getOctokit } from "@actions/github";
 interface PullRequestDetailsResponse {
   repository: {
     pullRequest: {
-      headRef: {
+      headRef?: {
         name: string;
         target: {
           oid: string;
@@ -70,7 +70,7 @@ export async function pullRequestDetails(token: string) {
   return {
     base_ref: baseRef.name,
     base_sha: baseRef.target.oid,
-    head_ref: headRef.name,
-    head_sha: headRef.target.oid,
+    head_ref: headRef?.name,
+    head_sha: headRef?.target.oid,
   };
 }


### PR DESCRIPTION
When a PR branch is deleted the `repository.pullRequest.headRefs` is null. This change is aware of that.
Currently the following error happens if the action is used on a PR with a deleted branch (closed or merged):

```
Error: Cannot read property 'name' of null
(node:1474) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'name' of null
    at pullRequestDetails (/home/runner/work/_actions/storyai/pull-request-comment-branch/v1/webpack:/pull-request-comment-branch/src/PullRequests.ts:38:1)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at run (/home/runner/work/_actions/storyai/pull-request-comment-branch/v1/webpack:/pull-request-comment-branch/src/main.ts:9:1)
```