### PR TITLE
Remove deprecated `ref` and `sha` outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Updated node runtime from 12 to 16
+- Removed deprecated `ref` and `sha` outputs. If you're using these then you should switch to `head_ref` and `head_sha` respectively.
 
 ## [1.4.0](https://github.com/xt0rted/pull-request-comment-branch/compare/v1.3.0...v1.4.0) - 2022-10-23
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ Name | Decription
 `base_sha` | The head sha of the branch the pull request will merge into.
 `head_ref` | The name of the pull request branch the comment belongs to.
 `head_sha` | The head sha of the pull request branch the comment belongs to.
-`ref` | Deprecated, use `head_ref` instead.
-`sha` | Deprecated, use `head_sha` instead.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -23,11 +23,6 @@ outputs:
     description: "The name of the pull request branch the comment belongs to."
   head_sha:
     description: "The head sha of the pull request branch the comment belongs to."
-# deprecated outputs
-  ref:
-    description: "Deprecated, use head_ref instead."
-  sha:
-    description: "Deprecated, use head_sha instead."
 
 runs:
   using: "node16"

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,10 +21,6 @@ export async function run() {
     setOutput("base_sha", base_sha);
     setOutput("head_ref", head_ref);
     setOutput("head_sha", head_sha);
-
-    // Deprecated
-    setOutput("ref", head_ref);
-    setOutput("sha", head_sha);
   } catch (error) {
     if (error instanceof Error) {
       setFailed(error.message);


### PR DESCRIPTION
The `ref` and `sha` outputs were deprecated over 2 years ago in v1.2.0 so since the next release is v2 they're going away now.