### PR TITLE
Update Node.js to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 16
-          - 18
+          - 20
 
     steps:
       - name: Checkout repo

--- a/action.yml
+++ b/action.yml
@@ -25,5 +25,5 @@ outputs:
     description: "The head sha of the pull request branch the comment belongs to."
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
fix https://github.com/xt0rted/pull-request-comment-branch/issues/418

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Node.js 16 actions are deprecated.
Therefore, I update Node.js used in this Action to 20.