### PR TITLE
Close #502: Update node runtime from 20 to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         node:
-          - 20
           - 22
+          - 24
 
     steps:
       - name: Checkout repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## [4.0.0](https://github.com/xt0rted/pull-request-comment-branch/compare/v3.0.0...v4.0.0) - 2026-03-18
+
+- Updated node runtime from 20 to 24
+
 ## [3.0.0](https://github.com/xt0rted/pull-request-comment-branch/compare/v2.0.0...v3.0.0) - 2024-11-19
 
 - Updated node runtime from 16 to 20

--- a/action.yml
+++ b/action.yml
@@ -25,5 +25,5 @@ outputs:
     description: "The head sha of the pull request branch the comment belongs to."
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pull-request-comment-branch",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "private": true,
   "description": "Gets the head ref and sha of a pull request comment",
   "main": "dist/index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES2022",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "ES2024",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "Node16",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
Addresses GitHub's deprecation of Node.js 20 actions (forced Node.js 24 default starting June 2nd, 2026).

- action.yml: using node20 → node24
- tsconfig.json: target ES2022 → ES2024
- CI matrix: [20, 22] → [22, 24]
- Version bump: 3.0.0 → 4.0.0

Closes #502